### PR TITLE
Game management start, error handling and a bit of docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2506,6 +2506,7 @@ version = "0.1.0"
 dependencies = [
  "ggez",
  "hashbrown 0.14.0",
+ "lazy_static",
  "log",
  "networking",
  "ron",

--- a/client/src/game/mod.rs
+++ b/client/src/game/mod.rs
@@ -1,3 +1,12 @@
-pub struct Game {}
+pub struct Game {
+    
 
-impl Game {}
+}
+
+impl Game {
+    pub fn new() -> Self{
+        Self{
+
+        }
+    }
+}

--- a/client/src/game/state.rs
+++ b/client/src/game/state.rs
@@ -1,0 +1,6 @@
+pub enum State{
+    Disconnected,
+    Connected{
+        GameId: usize,
+    }
+}

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -94,7 +94,6 @@ impl ggez::event::EventHandler for Chess {
         self.gui_menu.draw(ctx, render_request)?;
         self.ui_mgr.draw(ctx, render_request)?;
 
-
         let render_log = self.renderer.run(ctx, self.gui_menu.backend_mut())?;
 
         self.frame_stats.set_render_log(render_log);

--- a/server/src/game/mod.rs
+++ b/server/src/game/mod.rs
@@ -1,1 +1,0 @@
-mod gamestate;

--- a/server/src/game_manager/game.rs
+++ b/server/src/game_manager/game.rs
@@ -1,0 +1,45 @@
+
+pub struct Game{
+    id: shared::id::Id,
+    player1: Option<super::Player>,
+    player2: Option<super::Player>,
+
+    state: super::State,
+}
+
+impl Game{
+    pub fn new() -> Self{
+        Self{
+            id:shared::id::Id::new(),
+            player1: None,
+            player2: None,
+            state: super::State::default(),
+        }
+    }
+
+    pub fn id(&self) -> shared::id::Id{
+        self.id
+    }
+
+    pub fn connect_player(&mut self, new_player: super::Player) -> Result<(), shared::error::server::GameError>{
+        if self.player1.is_none(){
+            self.player1 = Some(new_player);
+        }else if self.player2.is_none(){
+            self.player2 = Some(new_player);
+        }else{
+            return Err(shared::error::server::GameError::SessionIsFull)
+        }
+
+        Ok(())
+
+    }
+
+    pub fn is_active(&self) -> bool{
+        self.player1.is_some() || self.player2.is_some()
+    }
+
+    pub fn update(&mut self){
+
+    }
+}
+

--- a/server/src/game_manager/mod.rs
+++ b/server/src/game_manager/mod.rs
@@ -1,0 +1,79 @@
+mod game;
+mod player; 
+mod state;
+
+pub use game::Game;
+pub use player::Player;
+pub use state::State;
+
+
+pub struct GameManager{
+    active_games: Vec<game::Game>,
+    inactive_players: Vec<player::Player>,
+}
+
+
+impl GameManager{
+    pub fn new() -> Self{
+        Self {
+            active_games: Vec::default(),
+            inactive_players: Vec::new(),
+        }
+    }
+
+    pub fn register_new_game(&mut self, new_game: game::Game){
+        self.active_games.push(new_game)
+    }
+
+    fn clean_inactive(&mut self){
+        let mut i = 0;
+
+        while i < self.active_games.len(){
+            
+            let game = self.active_games.get_mut(i).unwrap();
+
+            if !game.is_active(){
+                println!("Removing game {} koz it's empty", game.id());
+                self.active_games.remove(i);
+            }else{
+                i +=1;
+            }
+        }
+        // self.active_games.retain(|game| game.is_active())
+    }
+
+
+    /// 'Steals' the clients from the server and registers them as player to store them in the list of inactive players
+    fn register_new_players(&mut self, server: &mut crate::networking::Server<
+        shared::message::ClientMessage,
+        shared::message::ServerMessage,
+    >){
+        let clients_ref = server.clients();
+
+        while let Some(client) = clients_ref.pop(){
+            let new_player = Player::new(client);
+
+            debug!("A new player with id: {} has been registered by the game manager", new_player.id());
+
+            self.inactive_players.push(new_player);
+        }
+    }
+
+    fn update_games(&mut self){
+        for game in &mut self.active_games{
+            game.update();
+        }
+    }
+
+    fn update_connected_players(&mut self, ){
+        for player in &mut self.inactive_players{
+            player.update();
+        }
+    }
+
+    pub fn update(&mut self, server: &mut crate::networking::Server<shared::message::ClientMessage,shared::message::ServerMessage>){
+        self.clean_inactive();
+        self.register_new_players(server);
+        self.update_games();
+    }
+}

--- a/server/src/game_manager/player.rs
+++ b/server/src/game_manager/player.rs
@@ -1,0 +1,23 @@
+pub struct Player{
+    // id: shared::id::Id,
+    client: crate::networking::Client<shared::message::ClientMessage, shared::message::ServerMessage>,
+    
+}
+
+
+impl Player{
+    pub fn new(client: crate::networking::Client<shared::message::ClientMessage, shared::message::ServerMessage>) -> Self{
+        Self{
+            // id: shared::id::Id::new(),
+            client,
+        }
+    }
+
+    pub fn id(&self) -> shared::id::Id{
+        self.client.id()
+    }
+
+    pub fn update(&mut self){
+        self.client.update().unwrap();
+    }
+}

--- a/server/src/game_manager/state.rs
+++ b/server/src/game_manager/state.rs
@@ -1,0 +1,15 @@
+#[derive(Default)]
+pub enum State{
+    #[default]
+    Waiting,
+    PLaying{
+        // infos about the games / board etc..
+    }
+
+}
+
+
+
+impl State{
+
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,12 +1,13 @@
 #[macro_use]
 extern crate log;
-mod game;
+mod game_manager;
 mod networking;
 mod utils;
 const TARGET_TPS: f32 = 10.;
 
 fn main() {
-    let config = logger::LoggerConfig::default();
+
+    let config = logger::LoggerConfig::default().set_level(log::LevelFilter::Debug);
 
     logger::init(config, Some("server.log"));
 
@@ -22,6 +23,8 @@ fn main() {
         shared::message::ServerMessage,
     >::new(shared::DEFAULT_ADDRESS);
 
+    let mut game_mgr= game_manager::GameManager::new();
+
     debug!("Starting loop with {TARGET_TPS}TPS");
 
     while running.load(std::sync::atomic::Ordering::SeqCst) {
@@ -29,10 +32,10 @@ fn main() {
 
         server.update();
 
+        game_mgr.update(&mut server);
+
         loop_helper.loop_sleep();
     }
-
-    // spin_sleep::sleep(std::time::Duration::from_secs_f32(1.5));
 
     debug!(
         "Stopping loop. The server ran {}",

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -22,3 +22,4 @@ networking.workspace = true
 time.workspace = true
 ron.workspace = true
 hashbrown.workspace = true
+lazy_static = "1.4.0"

--- a/shared/src/chess/bitboard.rs
+++ b/shared/src/chess/bitboard.rs
@@ -6,6 +6,7 @@ impl BitBoard {
     pub fn set(&mut self, position: impl Into<super::Position>) {
         let index = position.into().to_index();
 
+
         let b = BitBoard::from(1u64 << index);
         self.add(b);
     }
@@ -50,8 +51,8 @@ impl std::fmt::Debug for BitBoard {
 impl std::fmt::Display for BitBoard {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let mut s: String = format!("BitBoard({})\n", self.0);
-
         for col in (0..8).rev() {
+            s.push_str(&format!("{} ", col +1));
             for row in 0..8 {
                 let pos = super::Position::from_index(row, col).unwrap();
                 let index = pos.to_index();
@@ -65,6 +66,7 @@ impl std::fmt::Display for BitBoard {
                 }
             }
         }
+        s.push_str("  A B C D E F G H");
 
         write!(f, "{}", s)
     }
@@ -191,9 +193,13 @@ mod tests {
 
         assert_eq!(b, BitBoard(1));
 
-        b.set((3, 6));
+        let p = super::super::Position::from((3, 6));
 
-        assert_eq!(b, BitBoard(1073741825))
+        println!("Setting square {p}");
+
+        b.set(p);
+
+        assert_eq!(b, BitBoard(2251799813685249)) // 1073741825 With the other index method
     }
 
     #[test]
@@ -205,7 +211,22 @@ mod tests {
         assert_eq!(b, BitBoard(987654321987654320));
 
         b.unset((2, 4));
+                                
+        assert_eq!(b, BitBoard(987654304807785136)) // 987654321986605744 With the other index method
+    }
 
-        assert_eq!(b, BitBoard(987654321986605744))
+    #[test]
+    fn display(){
+        use super::super::{Position, File, Rank};
+        let mut b = BitBoard(0);
+
+        b.set(Position::from_file_rank(File::F, Rank::Three));
+
+        b.set((File::A, Rank::One));
+        b.set((File::A, Rank::Four));
+
+        b.set((File::H, Rank::Eight));
+
+        println!("{b}");
     }
 }

--- a/shared/src/chess/board.rs
+++ b/shared/src/chess/board.rs
@@ -1,6 +1,5 @@
 pub struct Board {
     active_player: super::Color,
-    pieces: crate::maths::Vec2D<Option<super::Piece>>,
     white_bb: super::BitBoard,
     black_bb: super::BitBoard,
 
@@ -10,8 +9,7 @@ pub struct Board {
 impl Board {
     pub fn from_fen(fen: &str) -> Option<Self> {
         let mut board = Self {
-            active_player: super::Color::White,       // White always starts
-            pieces: crate::maths::Vec2D::new_empty(), // Make a new from fen string
+            active_player: super::Color::default(),    // White always starts (Unless the FEN string says otherwise)
             white_bb: super::BitBoard::default(),
             black_bb: super::BitBoard::default(),
             piece_bb: hashbrown::HashMap::default(),
@@ -28,8 +26,6 @@ impl Board {
             .collect::<Vec<String>>();
 
         if tokens.len() < 4 {
-            println!("Invalid FEN string ({fen})");
-
             error!("Invalid FEN string ({fen})");
             return None;
         }
@@ -57,7 +53,6 @@ impl Board {
 
             // Else, match the piece or return an error if it's no understood
             let Some(piece) = super::Piece::from_fen_char(p) else{
-                println!("Could not convert FEN '{p}' to piece");
                 error!("Could not convert FEN '{p}' to piece");
                 return  None
             };
@@ -72,8 +67,6 @@ impl Board {
 
         // 'Deserialize' the active player
         if active_player.len() != 1 {
-            println!("Could not understand the active player of fen ({fen})");
-
             error!("Could not understand the active player of fen ({fen})");
             return None;
         }
@@ -81,7 +74,6 @@ impl Board {
             "w" => board.active_player = super::Color::White,
             "b" => board.active_player = super::Color::Black,
             _ => {
-                println!("Could not get the active player from fen string ({fen})");
                 error!("Could not get the active player from fen string ({fen})");
                 return None;
             }
@@ -115,11 +107,7 @@ impl Board {
     }
 
     pub fn flip(&mut self) {
-        let w = self.white_bb;
         self.white_bb.flip();
-        if self.white_bb == w {
-            println!("problem");
-        }
         self.black_bb.flip();
         for (_piece, bb) in self.piece_bb.iter_mut() {
             bb.flip();

--- a/shared/src/chess/position.rs
+++ b/shared/src/chess/position.rs
@@ -1,5 +1,25 @@
-use std::fmt::Display;
 
+/*
+
+    Note to understand how this should work
+    
+    let mut b = BitBoard(0);
+
+    b.set((3, 6));
+
+    Should make the board b:
+    BitBoard(2251799813685249)
+    8 • • • • • • • •
+    7 • • • X • • • •
+    6 • • • • • • • •
+    5 • • • • • • • •
+    4 • • • • • • • •
+    3 • • • • • • • •
+    2 • • • • • • • •
+    1 • • • • • • • •
+      A B C D E F G H 
+    Because its setting the square D7
+*/ 
 #[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Position {
     file: File, // x
@@ -209,6 +229,12 @@ impl From<(u8, u8)> for Position {
     }
 }
 
+impl From<(super::File, super::Rank)> for Position{
+    fn from(value: (super::File, super::Rank)) -> Self {
+        Position::from_file_rank(value.0, value.1)        
+    }
+}
+
 impl ToString for File {
     fn to_string(&self) -> String {
         match self {
@@ -239,7 +265,7 @@ impl ToString for Rank {
     }
 }
 
-impl Display for Position {
+impl std::fmt::Display for Position {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}{}", self.file.to_string(), self.rank.to_string())
     }
@@ -290,9 +316,9 @@ mod tests {
 
     #[test]
     fn index() {
-        assert_eq!(Position::from_index(2, 4).unwrap().to_index(), 20);
+        assert_eq!(Position::from_index(2, 4).unwrap().to_index(), 34);
 
-        assert_eq!(Position::from_index(3, 6).unwrap().to_index(), 30);
+        assert_eq!(Position::from_index(3, 6).unwrap().to_index(), 51);
 
         assert_eq!(Position::from_index(0, 0).unwrap().to_index(), 0);
 

--- a/shared/src/error/client.rs
+++ b/shared/src/error/client.rs
@@ -1,0 +1,3 @@
+pub enum ClientError{
+    
+}

--- a/shared/src/error/mod.rs
+++ b/shared/src/error/mod.rs
@@ -1,0 +1,2 @@
+pub mod client;
+pub mod server;

--- a/shared/src/error/server.rs
+++ b/shared/src/error/server.rs
@@ -1,0 +1,19 @@
+#[derive(thiserror::Error, Debug)]
+pub enum ServerError{
+    #[error(transparent)]
+    Game(GameError),
+    #[error(transparent)]
+    Client(ClientError)
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum GameError{
+    #[error("The session is full")]
+    SessionIsFull
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum ClientError{
+    #[error("The proxy for the client '{0}' has disconnected")]
+    ProxyDisconnected(std::net::SocketAddr)
+}

--- a/shared/src/game/mod.rs
+++ b/shared/src/game/mod.rs
@@ -1,0 +1,11 @@
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Clone)]
+pub struct Game{
+    id: crate::id::Id,
+    players: Option<Player>
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Clone)]
+pub struct Player{
+    id: crate::id::Id,
+    name: String,
+}

--- a/shared/src/id.rs
+++ b/shared/src/id.rs
@@ -27,7 +27,7 @@ use core::{
 macro_rules! IdImpl {
   ( $(#[$docs:meta])* struct $name: ident, $int_type:ty, $non_zero_type:ty, $atomic_type: ty ) => {
     $(#[$docs])*
-    #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+    #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
     #[repr(transparent)]
     pub struct $name {
         id: $non_zero_type,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -5,8 +5,10 @@ pub const DEFAULT_ADDRESS: std::net::SocketAddr = std::net::SocketAddr::V4(
     std::net::SocketAddrV4::new(std::net::Ipv4Addr::new(127, 0, 0, 1), 19864),
 );
 
+pub mod error;
 pub mod chess;
 pub mod file;
 pub mod id;
 pub mod maths;
 pub mod message;
+pub mod game;

--- a/shared/src/message.rs
+++ b/shared/src/message.rs
@@ -3,12 +3,17 @@ pub enum ClientMessage {
     Text(String),
     Ping,
     Pong,
+    // Get the available games that the server is hosting
+    RequestAvailableGames
 }
+
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Clone)]
 pub enum ServerMessage {
     Text(String),
     Ping,
     Pong,
+    // Send a list of games (only send the useful informations, don't give everything)
+    AvailableGames(Vec<crate::game::Game>),
 }
 
 impl networking::Message for ClientMessage {


### PR DESCRIPTION
Server
    Simple game management
    All connected clients are now stored in a inactive client list in the game manager
    Cleaner methods in the part that accept new clients

Client:
    Started game management

Shared:
    Now holds struct for error handling
    Added docs to chess